### PR TITLE
update upload documentation

### DIFF
--- a/doc/upload.md
+++ b/doc/upload.md
@@ -88,5 +88,5 @@ upload directories or symbolic links.
 
 The process will monitor `UPLOAD_DIR` for new files, but it won't
 start uploading them until they have been present in the directory for
-at least ten minutes without changing; this is to avoid uploading
+at least 2 minutes without changing; this is to avoid uploading
 partial files.


### PR DESCRIPTION
The upload documentation specify that the command is checking that a file hasn't changed for at least 10 minutes, but the code seems to have changed to 2 minutes instead in src/Ambiata/Cli.hs:94.

If that is indeed the case, feel free to accept my merge to update the doco accordingly.